### PR TITLE
The additions to /etc/services are needed for the client to operate,

### DIFF
--- a/mrsh.spec.in
+++ b/mrsh.spec.in
@@ -77,13 +77,15 @@ DESTDIR="$RPM_BUILD_ROOT" make install
 %{_bindir}/rsh
 %{_bindir}/rlogin
 
-%post server
+%post
 if ! grep "^mshell" /etc/services > /dev/null; then
         echo "mshell          21212/tcp                  # mrshd" >> /etc/services
 fi
 if ! grep "^mlogin" /etc/services > /dev/null; then
         echo "mlogin            541/tcp                  # mrlogind" >> /etc/services
 fi
+
+%post server
 # 'condrestart' is not portable
 if [ -x /etc/init.d/xinetd ]; then
     if /etc/init.d/xinetd status | grep -q running; then


### PR DESCRIPTION
even if the server portion is not installed.
The %post script is probably not set up right (as-is, it will probably
get added to rsh-compat too, but 1) RPM is not my strong suite, and 2)
it gave you an idea of what I was shooting for.

Work funded by Intel's High Performance Data Division
