### PR TITLE
properly NULL terminate function call to fix: warning: missing sentin…

### DIFF
--- a/mrshd/mrshd.c
+++ b/mrshd/mrshd.c
@@ -615,7 +615,7 @@ error_out:
 	 */
 	for (ifd = getdtablesize()-1; ifd > 2; ifd--) close(ifd);
 
-	execl(theshell, shellname, "-c", cmdbuf, 0);
+	execl(theshell, shellname, "-c", cmdbuf, (char *)NULL);
 	perror(theshell);
 	exit(1);
 }


### PR DESCRIPTION
…el in function call

I also see the same thing in the array declaration on line 148. Compiler didn't complain about that one so I didn't rock the boat anymore than I needed to.