### PR TITLE
Add KillMode=process to handle various scenarios where mrsh is used t…

### DIFF
--- a/etc/systemd/mrshd@.service
+++ b/etc/systemd/mrshd@.service
@@ -4,3 +4,4 @@ Description=Mrshd Server
 [Service]
 ExecStart=-/usr/sbin/in.mrshd
 StandardInput=socket
+KillMode=process


### PR DESCRIPTION
…o start daemon-like processes on the other end.

Example:

rsh e3 'echo begin; exec 2>/dev/null; sleep 2; echo end'

will hang if KillMode=process not set

Example by Py Watson (watson30@llnl.gov)

Solution determined by Py Watson and Herb Wartens (wartens2@llnl.gov)

Signed-off-by: Albert L. Chu <chu11@llnl.gov>