### PR TITLE
Include grp.h to define initgroups()

### DIFF
--- a/mrlogind/auth.c
+++ b/mrlogind/auth.c
@@ -66,6 +66,7 @@
 
 #include <sys/types.h>
 #include <pwd.h>
+#include <grp.h>
 
 #include "mrlogind.h"
 


### PR DESCRIPTION
This gets rid of an implicit declaration warning for initgroups() in mrlogind/auth.c.
There are more warnings with newer versions of gcc however, this is more serious.

Signed-off-by: Egbert Eich <eich@suse.com>